### PR TITLE
Migrate Apiary source to public docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ This repo has three subdirectories:
   and instruction snippets.
 * **json/** -- Table data in JSON format. Mainly used on the Downloads and Dash
   Datasheet pages.
+
+The root directory also contains **apiary.apib**. This is the source for
+our [HTTP API docs](http://docs.hologram.apiary.io/#), hosted on Apiary.

--- a/apiary.apib
+++ b/apiary.apib
@@ -1,0 +1,786 @@
+FORMAT: 1A
+HOST: https://dashboard.hologram.io
+
+# Hologram
+
+The Hologram HTTP API is a REST-style interface for managing Hologram devices,
+accounts, and cloud data.
+
+## Requests
+
+To authenticate to the API, you must provide your API key as a query string parameter in each request.
+Find your API key on the Hologram Dashboard under 
+[Account Settings](https://dashboard.hologram.io/account/api):
+
+![API key screenshot](http://hologram.io/wp-content/uploads/2016/12/apikey.png)
+
+Your API key gives you access to your personal account, as well as any organizations
+you are a member of. Many API endpoints accept an `orgid` argument to filter for devices or other objects
+within a specific organization.
+
+Request bodies can be provided in either JSON or form-urlencoded formats. In the reference examples below, 
+only the JSON versions are shown, and the `apikey` query string parameter is omitted for brevity.
+
+### Examples
+
+**GET**
+
+```
+curl --verbose --request GET \
+'https://dashboard.hologram.io/api/1/users/me?apikey=2rjpYZZNzFAoGxAgEP2SC6moL3emyB'
+```
+
+**POST with JSON body**
+
+```
+curl --verbose --request POST \
+--header "Content-Type: application/json" \
+--data '{"deviceid": 56668, "body": "Hello device!"}' \
+'https://dashboard.hologram.io/api/1/sms/incoming?apikey=2rjpYZZNzFAoGxAgEP2SC6moL3emyB'
+```
+
+**POST with form-urlencoded body**
+
+```
+curl --verbose --request POST \
+--header "Content-Type: application/x-form-urlencoded" \
+--data 'deviceid=56668&body=Hello%20device!' \
+'https://dashboard.hologram.io/api/1/sms/incoming?apikey=2rjpYZZNzFAoGxAgEP2SC6moL3emyB'
+```
+
+## Responses
+
+All API responses are returned as JSON objects with the following fields:
+
+* `success` (boolean) - Indicates whether the request was successful.
+* `data` (object or array) - Contains the requested data or information about
+  the operation that was performed. Only present when `success` is true.
+* `error` (string) - Information about why the request failed. Only present when
+  `success` is false.
+
+In addition to these body fields, the API uses standard HTTP status codes
+to indicate success (200) and common errors (403 Forbidden, etc).
+
+### Examples
+
+**Success response**
+
+```
+{
+  "success": true,
+  "data": {
+    "msgcount": 1
+  }
+}
+```
+
+**Error response**
+
+```
+{
+  "success": false,
+  "error": "Not logged in"
+}
+```
+
+## Data Structures
+
+### User (object)
+
++ id: 1234 (number) - Unique user id
++ email: joe@example.com (string, required) - Email address of user. 
+    This is the address that is used for logging into the Hologram Dashboard.
++ partnerid: 123 (number)ds
++ first: Joe (string) - First name
++ last: Schmoe (string) - Last name
++ role (string) - Indicates if the user is an admin. Normally empty.
++ registered (string) - Date that the user created her account
+    + Sample: 2015-05-30 20:41:28
++ billingmethod (string)
+
+### Organization (object)
+
++ id: 2345 (number) - Unique ID for the organization
++ name: Smart Things LLC (string) - Display name
++ is_personal: false (boolean) - Is this organization a personal organization belonging to a single user?
++ ownerid: 1234 (number) - ID of the user that created the organization
++ users (array) - Members of the organization
++ pending (array) - Users with pending invitations to the organization
+
+### OrgUser (object)
+
++ id: 1234 (number) - Unique user id
++ email: joe@example.com (string) - Email address of user. 
++ first: Joe (string) - First name
++ last: Schmoe (string) - Last name
++ permissions (array) - Which actions the user has permission to perform
+    + billing
+    + activation
+    + changeplan
+
+### Account Balance (object)
+
++ userid: 1234 (number)
++ orgid: 2345 (number) - Organization ID
++ balance: 96.05 (string) - User balance
++ promobalance: 0.00 (string) - Additional balance from promotions
++ minbalance: 50.00 (string) - Auto reload minimum balance as configured in the dashboard
++ topoffamount: 0.00 (string) - Auto reload amount as configured in the dashboard
++ pendingcharges: 0 (string)
+
+### Order Data (object)
+
++ preview: false (boolean) - Was the request a preview (true) or an actual transaction (false)?
++ sku: ACCTREFILL (string)
++ unit_cost: 123.50 (number)
++ total_cost: 123.50 (number)
++ description: Refill Account Balance (string)
++ extra_description: User purchased account refill (string)
++ needs_shipping: false (boolean)
++ shipping_cost: 0 (number)
+
+### Cellular Link (object)
+
++ id: 4321 (number) - The link's unique integer ID
++ deviceid: 1234 (number) - Device ID corresponding to the link
++ devicename: "My Device" (string) - Description of the device
++ orgid: 123 (number) - ID of the organization that owns the link
++ tunnelable: 0 (number) - Is tunneling enabled for the link? (1=true, 0=false)
++ partnerid (number)
++ sim: 9990000000000001234 (string) - SIM number corresponding to the link
++ msisdn: 999900001234 (string) - MSISDN corresponding to the link
++ imsi: 123456789876543 (number) - IMSI corresponding to the link
++ dataplansubscriptionid: 75 (number) - The link's data plan type
++ tier: 1 (number) - Geographical zone of the link's data plan
++ carrier: 2 (number) - ID of the carrier that the link last connected to
++ state: LIVE (string) - State of the link (LIVE, PAUSE, DEACTIVATE)
++ whenclaimed (string) - Timestamp when the SIM was activated
+    + Sample: 2016-10-17 15:56:16
++ whenexpires (string) - Timestamp when the current billing period ends, or when the subscription expired
+    + Sample: 2017-01-15 15:59:53
++ whencreated (string) - Timestamp when the link's record was first created
+    + Sample: 2016-10-04 04:57:17
++ overagelimit: 20000 (number) -
+    Configured overage limit, or -1 if no limit is set. See the 
+    [guide](https://hologram.io/docs/guide/connect/device-management#data-and-overage-limits) 
+    for details on overage limits.
++ apn: hologram (string) - APN to use when connecting with this link's SIM card
+
+### Data Plan (object)
+
++ id: 127 (number) - Unique integer ID for the data plan
++ partnerid: 1 (number) - unused
++ name: 1 MB (string) - Human-readable name
++ description (string)
++ data: 1000000 (number) - Monthly data included in the plan (in bytes)
++ recurring: 1 (number) - for internal use
++ enabled: 1 (number) - Whether plan is available for new subscriptions
++ amount1: 0.99 (string) - Monthly base cost (zone 1)
++ amount2: 1.29 (string) - Monthly base cost (zone 2)
++ amount3 (string) - Monthly base cost (zone 3, unused)
+    + Sample: -1.00
++ amount4 (string) - Monthly base cost (zone 4, unused)
+    + Sample: -1.00
++ amount5 (string) - Monthly base cost (zone 5, unused)
+    + Sample: -1.00
++ billingperiod: 1 - for internal use
++ overage1: 1.00 (string) - Data overage cost per MB (zone 1)
++ overage2: 1.50 (string) - Data overage cost per MB (zone 2)
++ overage3 (string) - Data overage cost per MB (zone 3, unused)
+    + Sample: -1.00
++ overage4 (string) - Data overage cost per MB (zone 4, unused)
+    + Sample: -1.00
++ overage5 (string) - Data overage cost per MB (zone 5, unused)
+    + Sample: -1.00
++ sms1: 0.19 (string) - Outbound SMS cost per message (zone 1)
++ sms2: 0.30 (string) - Outbound SMS cost per message (zone 2)
++ sms3 (string) - Outbound SMS cost per message (zone 3, unused)
+    + Sample: -1.00
++ sms4 (string) - Outbound SMS cost per message (zone 4, unused)
+    + Sample: -1.00
++ sms5 (string) - Outbound SMS cost per message (zone 5, unused)
+    + Sample: -1.00
++ trialdays: 0 (string) - for internal use
++ templateid: 0 (string) - for internal use
++ carrierid: 2 (number) - for internal use
++ groupid: 0 (number) - for internal use
+
+### Device Tag (object)
+
++ name: My Tag (string) - Human-readable tag name
++ id: 123 (number) - Unique integer ID
++ deviceids (array) - IDs of devices linked to this tag
+    + 1234 (number)
+    + 1236 (number)
+
+### Device (object)
+
++ id: 1234 (number) - Integer device ID
++ orgid: 321 (number) - ID of the organization that owns the device (may be a personal organization)
++ name: My Device (string) - User-configurable device name
++ type (string) - for internal use
++ whencreated (string) - Timestamp when the device record was created
++ phonenumber (string) - Device phone number, if configured
++ tunnelable: 0 (number) - Is tunneling enabled for the device? 
+    See the [guide](https://hologram.io/docs/guide/cloud/spacebridge-tunnel) for details
++ hidden: 0 (number) - for internal use
++ tags (array) - Configurable device categories. See [Device Tags](#reference/device-management/device-tags/) for details.
++ links
+    + cellular (array) - Information about the device's SIM and data plan
+
+## Group Device Management
+
+See the [guide](https://hologram.io/docs/guide/connect/device-management)
+for details on devices, data plans, and related options.
+
+## Devices [/api/1/devices/{deviceid}]
+
+### List Devices [GET /api/1/devices{?orgid}]
+
++ Parameters
+    + orgid: 1234 (number, optional)
+        Only return results for the given organization ID
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (array)
+            + (Device)
+
+### Get a Device [GET /api/1/devices/{deviceid}]
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Device)
+
+## Cellular Links [/api/1/links/cellular]
+
+A Cellular Link is the association between a Device and a cellular data plan and SIM. Typically, 
+a device has exactly one Cellular Link.
+
+### Activate SIMs [POST /api/1/links/cellular/bulkclaim]
+
+Corresponds to the dashboard's [Activate SIM](https://dashboard.hologram.io/activate) page.
+Activating a SIM creates a new device and corresponding cellular link. 
+
++ Request (application/json)
+    + Attributes
+        + sims (array) - array of SIM numbers to activate
+            + 99990000000012345678
+        + plan: 73 (number) - 
+            Device data plan. Look up plan IDs with 
+            [List Data Plans](#reference/device-management/data-plans/list-data-plans).
+        + tier: 1 (number) - 
+            Geographic zone. Currently the valid tiers are `1` and `2`.
+            Higher tiers incur higher costs. See [pricing](https://hologram.io/pricing/) for details.
+        
++ Request Activate SIM range (application/json)
+    + Attributes
+        + simrange (string) - range of SIM numbers to activate
+            + Sample:  99990000000012345678-99990000000012345699
+        + plan: 73 (number) - 
+            Device data plan. Look up plan IDs with 
+            [List Data Plans](#reference/device-management/data-plans/list-data-plans).
+        + tier: 1 (number) - 
+            Geographic zone. Currently the valid tiers are `1` and `2`.
+            Higher tiers incur higher costs. See [pricing](https://hologram.io/pricing/) for details.
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (array)
+            + (object)
+                + device: 1234 (number) - Device ID of the new corresponding device
+                + link: 3214 (number) - ID of the new cellular link
+                + sim: 99990000000012345678 (string)
+        + order_data (Order Data)
+            + sku: PLAN
+            + unit_cost: 0.4
+            + total_cost: 0.4
+            + description: Data plan for SIMs 
+            + extra_description
+                + Sample: Plan:Pay-as-you-go
+
+### List Cellular Links [GET /api/1/links/cellular{?orgid}]
+
++ Parameters
+    + orgid: 1234 (number, optional)
+        Only return results for the given organization ID
+    
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (array)
+            + (Cellular Link)
+
+### Get Cellular Link [GET /api/1/links/cellular/{linkid}]
+
++ Parameters
+    + linkid: 54321 (number) - Integer ID of the link to retrieve
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Cellular Link)
+
+### Change Plan [POST /api/1/links/cellular/{linkid}/changeplan]
+
++ Parameters
+    + linkid: 54321 (number) - Integer ID of the link to change
+    
++ Request (application/json)
+    + Attributes
+        + planid: 73 (number) - 
+            Device data plan. Look up plan IDs with 
+            [List Data Plans](#reference/device-management/data-plans/list-data-plans).
+        + tier: 1 (number) - 
+            Geographic zone. Currently the valid tiers are `1` and `2`.
+            Higher tiers incur higher costs. See [pricing](https://hologram.io/pricing/) for details.
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + order_data (Order Data)
+            + sku: PLANCHANGE
+            + unit_cost: 2.23
+            + total_cost: 2.23
+            + description: Plan Change for 1 SIM
+            + transaction_type_id: PC (string)
+            + extra_description (string)
+                + Sample: Plan:5 MB
+
+### Change Overage Limit [POST /api/1/links/cellular/{linkid}/overagelimit]
+
++ Parameters
+    + linkid: 54321 (number) - Integer ID of the link to modify
+    
++ Request (application/json)
+    + Attributes
+        + limit: 20000 (number) - 
+            Number of bytes over the plan limit to allow. Set `-1` for no data limit. See the 
+            [guide](https://hologram.io/docs/guide/connect/device-management#data-and-overage-limits) for details.
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Cellular Link)
+
+### Pause or Unpause Data [POST /api/1/links/cellular/{linkid}/state]
+
++ Parameters
+    + linkid: 54321 (number) - Integer ID of the link to modify
+    
++ Request (application/json)
+    + Attributes
+        + state: pause (string) - New link state to set. One of: `pause`, `live`.
+        
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (object)
+            + newstate: PAUSED-PENDING-USER (string) - New state of the link. 
+                May be a 'pending' state until the change is propagated to the cellular network.
+
+
+## Device Tags [/api/1/devices/tags]
+
+Device tags are user-configurable categories that you can use to classify your devices. A device
+may be linked to more than one tag.
+
+### List Device Tags [GET /api/1/devices/tags]
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (array)
+            + (Device Tag)    
+
+### Create a Device Tag [POST /api/1/devices/tags]
+
++ Request (application/json)
+    + Attributes
+        + name: My Tag (string, required) - Name for the new tag
+        + deviceids (array, optional) - Devices to add to the new tag (optional)
+    
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Device Tag)
+
+### Delete a Device Tag [DELETE /api/1/devices/tags/{tagid}]
+
++ Parameters
+    + tagid: 1234 (number) - The ID of the tag to delete
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+
+### Link a Device to a Tag [POST /api/1/devices/tags/{tagid}/link]
+
++ Parameters
+    + tagid: 1234 (number) - The ID of the tag
+    
++ Request (application/json)
+    + Attributes
+        + deviceids (array) - List of device IDs to link to this tag
+            + 4321 (number)
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Device Tag)
+
+### Unlink a Device from a Tag [POST /api/1/devices/tags/{tagid}/unlink]
+
++ Parameters
+    + tagid: 1234 (number) - The ID of the tag
+
++ Request (application/json)
+    + Attributes
+        + deviceids (array) - List of device IDs to unlink from this tag
+            + 4321 (number)
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Device Tag)
+
+
+## Data Plans [/api/1/plans]
+
+The Data Plans endpoints return pricing and descriptions for the different data plans 
+that Hologram offers. When changing the data plan for a cellular link via API, 
+you must refer to the plan by its ID, which you can determine from these endpoints.
+
+### List Data Plans [GET /api/1/plans]
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (array)
+            + (Data Plan)
+    
+### Get a Data Plan [GET /api/1/plans/{planid}]
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Data Plan)
+
+
+## Group Hologram Cloud
+
+## CSR Messages [/api/1/csr/rdm]
+
+See the [guide](https://hologram.io/docs/guide/cloud/csr) for details on the 
+Cloud Services Router (CSR).
+
+### Send a CSR Message [POST]
+
++ Request (application/json)
+    + Attributes
+        + deviceid: 54321 (number) - Device ID to associate the message to
+        + tags (array, optional) - Additional topics to associate with the message. Optional
+        + data: Hello, Hologram! (string) - Data payload of the message
+
++ Response 200 (application/json)
+
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+
+### List CSR Messages [GET /api/1/csr/rdm{?deviceid,limit,orgid,tagname,timestampstart,timestampend}]
+
++ Parameters
+    + deviceid: 54321 (number, optional) - Optional. Filter for messages originating from one device
+    + limit: 100 (number, optional) - Return a maximum of this many messages. Default is 25
+    + orgid: 3222 (number, optional) - Filter for messages from devices belonging to this organization
+    + tagname: _RESTAPI_ (string, optional) - Filter for messages with a given topic
+    + timestampstart: 1480550400 (number, optional) - Only return messages received after this time (Unix timestamp)
+    + timestampend: 1480550400 (number, optional) - Only return messages received before this time (Unix timestamp)
+
++ Response 200
+    + Attributes
+        + id: 123432 (number) - Numerical identifier for the message
+        + logged (string) - Datetime when the message was received
+            + Sample: 2016-12-04 20:21:00
+        + deviceid: 1234 (number) - Device that the message originated from
+        + data (string) - Raw message data and metadata
+        + record_id (string) - the message's internal UUID
+            + Sample: 8e274992-cf84-11e5-a67e-bc764e20b516
+        + tags (array) - Topics (formerly called tags) associated with the message
+
++ Response 200 (application/json)
+
+        {
+          "success": true,
+          "continues": false,
+          "data": [
+            {
+              "id": 14,
+              "logged": "2015-04-09 15:59:59",
+              "deviceid": 77,
+              "data": "{\"source\":\"somesource\",\"tags\":[\"TestXYZ\",\"TestB\"],\"data\":\"dGVzdGRhdGEx\"}",
+              "record_id": "8e274992-cf84-11e5-a67e-bc764e20b516",
+              "tags": [
+                "TestB",
+                "TestXYZ"
+              ]
+            },
+            {
+              "id": 13,
+              "logged": "2015-04-08 21:05:42",
+              "deviceid": 1,
+              "data": "{\"source\":\"somesource\",\"tags\":[\"TestXYZ\",\"TestD\"],\"data\":\"dGVzdGRhdGEx\"}",
+              "record_id": "8e2748e7-cf84-11e5-a67e-bc764e20b516",
+              "tags": [
+                "TestD",
+                "TestXYZ"
+              ]
+            }
+          ]
+        }
+
+
+## SMS [/api/1/sms]
+
+### Send SMS to a device [POST /api/1/sms/incoming]
+
+There is no cost to send SMS messages to Hologram devices via API.
+
++ Request (application/json)
+    + Attributes
+        + deviceid: 1234 (number, required) - ID of the device to send to
+        + fromnumber: `+1-312-555-1212` (string, optional) - Phone number to display as the sender. Optional.
+        + body: Hello world! (string) - ASCII Text representation of the SMS body
+
++ Request With base64-encoded body (application/json)
+    + Attributes
+        + deviceid: 1234 (number, required) - ID of the device to send to
+        + fromnumber: `+1-312-555-1212` (string, optional) - Phone number to display as the sender. Optional.
+        + base64body: SGVsbG8sIFdvcmxkIQo= (string) - Base64-encoded message body
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+
+
+## Group Account Management
+
+## Current User [/api/1/users/me]
+
+### Get user info [GET]
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (User)
+
+
+## User Account Balance [/api/1/users/me/balance]
+
+Requests to the user account balance endpoints are equivalent to calling the 
+[organization account balance endpoints](#reference/account-management/organization-account-balance) 
+with the personal organization.
+
+### Get current balance [GET /api/1/users/me/balance]
+
++ Response 200 (application/json)
+
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Account Balance)
+
+### Add balance [POST /api/1/users/me/balance]
+
+Charge the user's configured billing source and add that amount to your account balance.
+
++ Request (application/json)
+
+    + Attributes
+        + addamount: 123.50 (number) - Amount to add to current user balance
+
++ Response 200 (application/json)
+
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + order_data (Order Data)
+
+### Get balance history [GET /api/1/users/me/balancehistory]
+
+Retreive a history of transactions (credits and charges).
+
++ Response 200 (application/json)
+
+        {
+          "success": true,
+          "data": [
+            {
+              "id": 54345,
+              "userid": 477,
+              "orgid":
+              "time": "2016-04-26 20:31:42",
+              "description": "Charge to balance: Data plan for SIM 8944502211130209115",
+              "amount": "-3.95"
+            },
+            {
+              "id": 54311,
+              "userid": 477,
+              "time": "2016-04-26 20:30:45",
+              "description": "one hundred",
+              "amount": "100.00"
+            }
+          ]
+        }
+
+## Organizations [/api/1/organizations/{orgid}]
+
+Organizations allow multiple users to share access to the same devices and billing account.
+See the [guide](https://hologram.io/docs/guide/connect/organizations) for more information.
+
+### List organizations [GET /api/1/organizations]
+
+List all organizations that you are a member of. This includes the special "personal" 
+organization tied to your user.
+
++ Response 200
+    + Attributes 
+        + success: true (boolean) - Was the request successful?
+        + data (array)
+            + (Organization)
+
++ Response 200 (application/json)
+
+        {
+          "success": true,
+          "data": [
+            {
+              "id": 5678,
+              "name": "Smart Things LLC",
+              "is_personal": 0,
+              "ownerid": 1234,
+              "users": [
+                {
+                  "id": 1234,
+                  "permissions": [
+                    "billing",
+                    "activation",
+                    "changeplan"
+                  ],
+                  "first": "Joe",
+                  "last": "Data",
+                  "email": "joe@example.com"
+                }
+              ],
+              "pending": []
+            },
+            {
+              "id": 2223,
+              "name": "joe@example.com",
+              "is_personal": 1,
+              "ownerid": 1234,
+              "users": [
+                {
+                  "id": 1234,
+                  "permissions": [
+                    "billing",
+                    "activation",
+                    "changeplan"
+                  ],
+                  "first": "Joe",
+                  "last": "Data",
+                  "email": "joe@example.com"
+                }
+              ],
+              "pending": []
+            }
+          ]
+        }
+
+### Get an organization [GET /api/1/organizations/{orgid}]
+
++ Parameters
+    + orgid: 4321 (number) - The organization's unique identifier
+
++ Response 200
+    + Attributes 
+        + success: true (boolean) - Was the request successful?
+        + data (Organization)
+
++ Response 200 (application/json)
+
+        {
+          "success": true,
+          "data": {
+            "id": 5678,
+            "name": "Smart Things LLC",
+            "is_personal": 0,
+            "ownerid": 1234,
+            "users": [
+              {
+                "id": 1234,
+                "permissions": [
+                  "billing",
+                  "activation",
+                  "changeplan"
+                ],
+                "first": "Joe",
+                "last": "Data",
+                "email": "joe@example.com"
+              }
+            ],
+            "pending": []
+          }
+        }
+
+## Organization Account Balance [/api/1/organizations/{orgid}/balance]
+
+### Get current balance [GET /api/1/organizations/{orgid}/balance]
+
++ Response 200 (application/json)
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + data (Account Balance)
+
+### Add balance [POST /api/1/organizations/{orgid}/balance]
+
+Charge the organization's configured billing source and add that amount to the account balance
+
++ Request (application/json)
+
+    + Attributes
+        + addamount: 123.50 (number) - Amount to add to current user balance
+
++ Response 200 (application/json)
+
+    + Attributes
+        + success: true (boolean) - Was the request successful?
+        + order_data (Order Data)
+
+### Get balance history [GET /api/1/organizations/{orgid}/balancehistory]
+
+Retrieve a history of transactions (credits and charges).
+
++ Response 200 (application/json)
+
+        {
+          "success": true,
+          "data": [
+            {
+              "id": 54345,
+              "userid": 477,
+              "orgid":
+              "time": "2016-04-26 20:31:42",
+              "description": "Charge to balance: Data plan for SIM 8944502211130209115",
+              "amount": "-3.95"
+            },
+            {
+              "id": 54311,
+              "userid": 477,
+              "time": "2016-04-26 20:30:45",
+              "description": "one hundred",
+              "amount": "100.00"
+            }
+          ]
+        }


### PR DESCRIPTION
Currently the source file for our Apiary docs lives in [its own repo](https://github.com/hologram-io/documentation-rest-api). Now that we have a more general public repo for documentation, it would make sense to merge the two. After this PR is merged we can update the Apiary config to point to this repository.